### PR TITLE
fix: 顧客管理画面のlocalStorage初回アクセス時のエラーを修正

### DIFF
--- a/frontend/src/pages/customer/CustomersPage.tsx
+++ b/frontend/src/pages/customer/CustomersPage.tsx
@@ -31,14 +31,42 @@ const CustomersPage = () => {
   const [page, setPage] = useState(0);
 
   const [rowsPerPage, setRowsPerPage] = useState<number>(() => {
-    const stored = localStorage.getItem(CUSTOMER_PAGE_SETTINGS_STORAGE_KEY)!;
-    const parsed = JSON.parse(stored) as CustomerPageSettings;
-    if (
-      typeof parsed.rowsPerPage === 'number' &&
-      VALID_PAGE_SIZES.includes(parsed.rowsPerPage as ValidPageSize)
-    ) {
-      return parsed.rowsPerPage;
+    // === 修正前のコード（エラーが発生する版） ===
+    // const stored = localStorage.getItem(CUSTOMER_PAGE_SETTINGS_STORAGE_KEY)!;
+    // const parsed = JSON.parse(stored) as CustomerPageSettings;
+    // if (
+    //   typeof parsed.rowsPerPage === 'number' &&
+    //   VALID_PAGE_SIZES.includes(parsed.rowsPerPage as ValidPageSize)
+    // ) {
+    //   return parsed.rowsPerPage;
+    // }
+    // return DEFAULT_SETTINGS.rowsPerPage;
+
+    // === 修正後のコード（nullチェックを追加） ===
+    try {
+      const stored = localStorage.getItem(CUSTOMER_PAGE_SETTINGS_STORAGE_KEY);
+
+      // nullチェック：localStorageにデータがない場合（初回アクセス時など）
+      if (!stored) {
+        return DEFAULT_SETTINGS.rowsPerPage;
+      }
+
+      const parsed = JSON.parse(stored) as CustomerPageSettings;
+
+      // 型とバリデーションチェック
+      if (
+        parsed &&
+        typeof parsed.rowsPerPage === 'number' &&
+        VALID_PAGE_SIZES.includes(parsed.rowsPerPage as ValidPageSize)
+      ) {
+        return parsed.rowsPerPage;
+      }
+    } catch (error) {
+      // JSON.parseエラーやその他の予期しないエラーをキャッチ
+      console.warn('Failed to load customer page settings:', error);
     }
+
+    // 何か問題があった場合はデフォルト値を使用
     return DEFAULT_SETTINGS.rowsPerPage;
   });
 


### PR DESCRIPTION
<!-- 必要に応じて変更してください -->

## Issue の URL
https://github.com/buysell-technologies/summer-internship-2025-0909-e/issues/8
<!-- https://github.com/your-organization/your-repository/issues/your-issue-number のリンクを貼ってください-->

## やったこと
 非nullアサーション演算子（`!`）を使用してTypeScriptの型エラーを回避していたが、初回アクセス時はlocalStorageが空（null）のため、実行時エラーが発生する。それによって`Cannot read properties of null`エラーで画面がクラッシュしていた
そこで、
- 非nullアサーション演算子を削除
- nullチェックを追加し、localStorageが空の場合はデフォルトの10件表示を使用
- try-catchでエラーハンドリングを追加
という対応によりエラーも考慮した堅牢な実装に変更した。
<!-- 対応したバグ・改善要望に対してどのような変更を加えたか説明をお願いします -->

## やらないこと

<!-- この PR でやらないことを書いてください -->

## 動作確認観点

<!-- 正常な動作を保証する画像や動画を貼ってください -->

- [x] セルフレビューを十分行い、Reviews を選択した
